### PR TITLE
Fix typo in error message

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -84,7 +84,7 @@ app.get('/', async (c) => {
       } catch (error) {
         console.error(error);
         return c.json({
-          error: 'An error occured',
+          error: 'An error occurred',
           debug: {
             error: null
           }


### PR DESCRIPTION
Correct the spelling of "occured" to "occurred" in the error message returned by the application.