### PR TITLE
Update dependencies for dotenv and hono packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@hono/node-server": "^1.17.1",
+        "@hono/node-server": "^1.18.1",
         "hono": "^4.8.12",
         "ical-generator": "^9.0.0",
         "node-ical": "^0.20.1",
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.17.1.tgz",
-      "integrity": "sha512-SY79W/C+2b1MyAzmIcV32Q47vO1b5XwLRwj8S9N6Jr5n1QCkIfAIH6umOSgqWZ4/v67hg6qq8Ha5vZonVidGsg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.18.1.tgz",
+      "integrity": "sha512-O3puG/b7owYYmoQ2XPBf3SxBz6Dhk5VmWFhbaBU8/5wcUaXUPS0goxaI2Zfyg+Cu14ILJHEU7IFRw7miFxuXxg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@hono/node-server": "^1.17.1",
-        "hono": "^4.8.5",
+        "hono": "^4.8.12",
         "ical-generator": "^9.0.0",
         "node-ical": "^0.20.1",
         "rrule": "^2.8.1"
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.8.5.tgz",
-      "integrity": "sha512-Up2cQbtNz1s111qpnnECdTGqSIUIhZJMLikdKkshebQSEBcoUKq6XJayLGqSZWidiH0zfHRCJqFu062Mz5UuRA==",
+      "version": "4.8.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.8.12.tgz",
+      "integrity": "sha512-MQSKk1Mg7b74k8l+A025LfysnLtXDKkE4pLaSsYRQC5iy85lgZnuyeQ1Wynair9mmECzoLu+FtJtqNZSoogBDQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "rrule": "^2.8.1"
       },
       "devDependencies": {
-        "dotenv": "^17.2.0"
+        "dotenv": "^17.2.1"
       }
     },
     "node_modules/@hono/node-server": {
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
-      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "node api/index.js"
   },
   "dependencies": {
-    "@hono/node-server": "^1.17.1",
+    "@hono/node-server": "^1.18.1",
     "hono": "^4.8.12",
     "ical-generator": "^9.0.0",
     "node-ical": "^0.20.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "rrule": "^2.8.1"
   },
   "devDependencies": {
-    "dotenv": "^17.2.0"
+    "dotenv": "^17.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.17.1",
-    "hono": "^4.8.5",
+    "hono": "^4.8.12",
     "ical-generator": "^9.0.0",
     "node-ical": "^0.20.1",
     "rrule": "^2.8.1"


### PR DESCRIPTION
Bump versions of dotenv, hono, and @hono/node-server to their latest releases to ensure compatibility and access to new features.