### PR TITLE
Update dependencies: dotenv, hono, and @hono/node-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@hono/node-server": "^1.19.0",
+        "@hono/node-server": "^1.19.1",
         "hono": "^4.9.6",
         "ical-generator": "^9.0.0",
         "node-ical": "^0.20.1",
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.0.tgz",
-      "integrity": "sha512-1k8/8OHf5VIymJEcJyVksFpT+AQ5euY0VA5hUkCnlKpD4mr8FSbvXaHblxeTTEr90OaqWzAkQaqD80qHZQKxBA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.1.tgz",
+      "integrity": "sha512-h44e5s+ByUriaRIbeS/C74O8v90m0A95luyYQGMF7KEn96KkYMXO7bZAwombzTpjQTU4e0TkU8U1WBIXlwuwtA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "packages": {
     "": {
       "dependencies": {
-        "hono": "^4.9.2",
         "@hono/node-server": "^1.19.0",
+        "hono": "^4.9.2",
         "ical-generator": "^9.0.0",
         "node-ical": "^0.20.1",
         "rrule": "^2.8.1"
       },
       "devDependencies": {
-        "dotenv": "^17.2.1"
+        "dotenv": "^17.2.2"
       }
     },
     "node_modules/@hono/node-server": {
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@hono/node-server": "^1.19.0",
-        "hono": "^4.9.2",
+        "hono": "^4.9.6",
         "ical-generator": "^9.0.0",
         "node-ical": "^0.20.1",
         "rrule": "^2.8.1"
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.2.tgz",
-      "integrity": "sha512-UG2jXGS/gkLH42l/1uROnwXpkjvvxkl3kpopL3LBo27NuaDPI6xHNfuUSilIHcrBkPfl4y0z6y2ByI455TjNRw==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.6.tgz",
+      "integrity": "sha512-doVjXhSFvYZ7y0dNokjwwSahcrAfdz+/BCLvAMa/vHLzjj8+CFyV5xteThGUsKdkaasgN+gF2mUxao+SGLpUeA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "rrule": "^2.8.1"
   },
   "devDependencies": {
-    "dotenv": "^17.2.1"
+    "dotenv": "^17.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "node api/index.js"
   },
   "dependencies": {
-    "hono": "^4.9.2",
+    "hono": "^4.9.6",
     "@hono/node-server": "^1.19.0",
     "ical-generator": "^9.0.0",
     "node-ical": "^0.20.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "hono": "^4.9.6",
-    "@hono/node-server": "^1.19.0",
+    "@hono/node-server": "^1.19.1",
     "ical-generator": "^9.0.0",
     "node-ical": "^0.20.1",
     "rrule": "^2.8.1"


### PR DESCRIPTION
- Upgrade dotenv to version 17.2.2, hono to version 4.9.6, and @hono/node-server to version 1.19.1 to incorporate the latest improvements and fixes.