### PR TITLE
Update dependencies and remove moment-timezone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@hono/node-server": "^1.19.5",
-        "hono": "^4.10.1",
+        "hono": "^4.10.3",
         "ical-generator": "^9.0.0",
         "node-ical": "^0.22.1",
         "rrule": "^2.8.1"
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.1.tgz",
-      "integrity": "sha512-rpGNOfacO4WEPClfkEt1yfl8cbu10uB1lNpiI33AKoiAHwOS8lV748JiLx4b5ozO/u4qLjIvfpFsPXdY5Qjkmg==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.3.tgz",
+      "integrity": "sha512-2LOYWUbnhdxdL8MNbNg9XZig6k+cZXm5IjHn2Aviv7honhBMOHb+jxrKIeJRZJRmn+htUCKhaicxwXuUDlchRA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.3.tgz",
       "integrity": "sha512-2LOYWUbnhdxdL8MNbNg9XZig6k+cZXm5IjHn2Aviv7honhBMOHb+jxrKIeJRZJRmn+htUCKhaicxwXuUDlchRA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -97,17 +98,6 @@
         }
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/node-ical": {
       "version": "0.22.1",
       "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.22.1.tgz",
@@ -125,6 +115,7 @@
       "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
       "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "@hono/node-server": "^1.19.5",
         "hono": "^4.10.1",
         "ical-generator": "^9.0.0",
-        "node-ical": "^0.22.0",
+        "node-ical": "^0.22.1",
         "rrule": "^2.8.1"
       },
       "devDependencies": {
@@ -45,7 +45,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.1.tgz",
       "integrity": "sha512-rpGNOfacO4WEPClfkEt1yfl8cbu10uB1lNpiI33AKoiAHwOS8lV748JiLx4b5ozO/u4qLjIvfpFsPXdY5Qjkmg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -104,14 +103,15 @@
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/node-ical": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.22.0.tgz",
-      "integrity": "sha512-wGSlJeogVgk2+p81b3VzyxEYkM8iBmQiDZAa1XsqzkAWrt0AWCVgcnxJPLVzyOCJrPUTdl8RZsdrV1Ub9dvn2g==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.22.1.tgz",
+      "integrity": "sha512-rMdc5hhJT3ZPtZIWfEXcetRrPl2xeHGpMJX8lq4VwyLKfOzGr+rXVtx0lD8lSf27Hn3mxrbU3MUcMSMXp4rIQA==",
       "license": "Apache-2.0",
       "dependencies": {
         "rrule": "2.8.1"
@@ -125,7 +125,6 @@
       "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
       "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.1.tgz",
       "integrity": "sha512-rpGNOfacO4WEPClfkEt1yfl8cbu10uB1lNpiI33AKoiAHwOS8lV748JiLx4b5ozO/u4qLjIvfpFsPXdY5Qjkmg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -103,21 +104,6 @@
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.0.tgz",
-      "integrity": "sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
       "engines": {
         "node": "*"
       }
@@ -139,6 +125,7 @@
       "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
       "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "node api/index.js"
   },
   "dependencies": {
-    "hono": "^4.10.1",
+    "hono": "^4.10.3",
     "@hono/node-server": "^1.19.5",
     "ical-generator": "^9.0.0",
     "node-ical": "^0.22.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "hono": "^4.10.1",
     "@hono/node-server": "^1.19.5",
     "ical-generator": "^9.0.0",
-    "node-ical": "^0.22.0",
+    "node-ical": "^0.22.1",
     "rrule": "^2.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade `hono` and `node-ical` to their latest patch versions, add peer dependency flags for `hono` and `rrule`, and remove `moment` and `moment-timezone` from the project.