### PR TITLE
Bump fastapi to version 0.135.2 and clarify TatSu pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Basic dependencies
-fastapi==0.135.1
+fastapi==0.135.2
 uvicorn[standard]==0.42.0
 # Additional dependencies
 httpx==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ uvicorn[standard]==0.42.0
 # Additional dependencies
 httpx==0.28.1
 ics==0.7.2
-TatSu==5.12.1 # pinned due to incompatibility with ics>=0.7.2 and newer TatSu versions
+TatSu==5.12.1 # pinned because newer TatSu versions are incompatible with ics>=0.7.2
 python-dotenv==1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ uvicorn[standard]==0.42.0
 # Additional dependencies
 httpx==0.28.1
 ics==0.7.2
-TatSu==5.12.1
+TatSu==5.12.1 # pinned due to incompatibility with ics>=0.7.2 and newer TatSu versions
 python-dotenv==1.2.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated FastAPI dependency to version 0.135.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->