### PR TITLE
Bump FastAPI and Uvicorn dependencies, update API version

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -70,7 +70,7 @@ async def lifespan(app: FastAPI):
 # FastAPI app instance
 app = FastAPI(
     title="Jona Ebert (they/them)",
-    version="26.5.1",
+    version="26.6.0",
     summary="Jona Ebert's Personal Website API",
     lifespan=lifespan,
     root_path=JE_API_ROOT_PATH,

--- a/app/main.py
+++ b/app/main.py
@@ -172,7 +172,6 @@ async def get_blog_posts(limit: int = 30, client: httpx.AsyncClient = Depends(_g
         "pagination[page]": 1,
         "pagination[pageSize]": limit,
         "populate[author][populate][avatar]": "true",
-        "populate[copyright]": "true",
         "populate[cover]": "true",
         "sort": "createdAt:desc",
     }
@@ -194,10 +193,8 @@ async def get_one_blog_post(post_id: str, client: httpx.AsyncClient = Depends(_g
         "populate[author][populate][avatar]": "true",
         "populate[blocks][on][shared.text][populate]": "*",
         "populate[blocks][on][shared.media][populate]": "*",
-        "populate[blocks][on][shared.copyright][populate]": "*",
         "populate[blocks][on][shared.slider][populate]": "*",
         "populate[blocks][on][shared.quote][populate]": "*",
-        "populate[copyright]": "true",
         "populate[cover]": "true",
         "sort": "createdAt:desc",
     }
@@ -221,7 +218,6 @@ async def get_calendar_events(limit: int = 30, client: httpx.AsyncClient = Depen
         "filters[end][$gte]": now.isoformat(),
         "pagination[page]": 1,
         "pagination[pageSize]": limit,
-        "populate[copyright]": "true",
         "populate[cover]": "true",
         "sort": "start:asc",
     }
@@ -239,7 +235,6 @@ async def get_calendar_events(limit: int = 30, client: httpx.AsyncClient = Depen
 
 async def fetch_one_calendar_event(event_id: str, client: httpx.AsyncClient):
     params = {
-        "populate[copyright]": "true",
         "populate[cover]": "true",
     }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Basic dependencies
 fastapi==0.136.3
-uvicorn[standard]==0.47.0
+uvicorn[standard]==0.48.0
 # Additional dependencies
 httpx==0.28.1
 ics==0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Basic dependencies
-fastapi==0.136.1
+fastapi==0.136.3
 uvicorn[standard]==0.47.0
 # Additional dependencies
 httpx==0.28.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application version updated to 26.6.0
  * Updated FastAPI dependency from 0.136.1 to 0.136.3
  * Updated Uvicorn dependency from 0.47.0 to 0.48.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->